### PR TITLE
Add PeptidePlaza to Blogs: free PubMed-sourced peptide reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ An [awesome](https://github.com/sindresorhus/awesome) list of longevity resource
 - [Longevity.technology](https://longevity.technology/)
 - [Longevity Marketcap Newsletter](https://sub.longevitymarketcap.com/)
 - [Longevity Protocols](https://longevity-protocols.com/) 
+- [PeptidePlaza](https://peptideplaza.com/): A free, PubMed-sourced reference covering 50+ research peptides, dosing/reconstitution guidance, and a community-vetted vendor directory.
 
 ## Forums
 - [VitaDao Discord](https://discord.com/invite/3S3ftnmZYD)


### PR DESCRIPTION
## What
Adds [PeptidePlaza](https://peptideplaza.com/) to the Blogs section as a free, PubMed-sourced peptide reference.

## Why it fits
Longevity Protocols (a reference site) is already listed under Blogs — PeptidePlaza follows the same pattern on the peptide-research side: 50+ compound profiles with PubMed citations, reconstitution/dosing guidance, and a community-vetted vendor directory. Pure educational resource — no sales, no affiliate links.

- [x] Format matches existing entries
- [x] Verified links resolve